### PR TITLE
Fix coloring of brackets and variables

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -103,7 +103,6 @@ atom-text-editor.is-focused, :host(.is-focused) {
 .entity.name.function,
 .meta.require,
 .support.function.any-method,
-.meta.function-call,
 .support.function,
 .keyword.other.special-method,
 .meta.block-level,


### PR DESCRIPTION
Fixes silvestreh/atom-material-syntax#27
A bunch of non-functions were being colored like functions